### PR TITLE
Fix quotes so it runs under Raspberry Pi with Python 3.11

### DIFF
--- a/src/meshcore_cli/meshcore_cli.py
+++ b/src/meshcore_cli/meshcore_cli.py
@@ -1464,7 +1464,7 @@ async def next_cmd(mc, cmds, json_output=False):
                     print(json.dumps(mc.pending_contacts, indent=4))
                 else:
                     for c in mc.pending_contacts.items():
-                        print(f"{c[1]["adv_name"]}: {c[1]["public_key"]}")
+                        print(f"{c[1]['adv_name']}: {c[1]['public_key']}")
 
             case "flush_pending":
                 mc.flush_pending_contacts()


### PR DESCRIPTION
Replace double quotes with single quotes, within double quotes.

This change resolves this error on Raspberry Pi:

```
Traceback (most recent call last):
  File "/home/pi/.local/bin/meshcli", line 5, in <module>
    from meshcore_cli.meshcore_cli import cli
  File "/home/pi/.local/pipx/venvs/meshcore-cli/lib/python3.11/site-packages/meshcore_cli/meshcore_cli.py", line 1381
    print(f"{c[1]["adv_name"]}: {c[1]["public_key"]}")
                   ^^^^^^^^
SyntaxError: f-string: unmatched '['

```